### PR TITLE
fix: update path in scanHandlers to use serverDir

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -28,12 +28,13 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.build.transpile.push(runtimeDir)
 
     nuxt.hook('builder:watch', async (e, path) => {
-      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
-      if (e === 'change') { return }
-      if (path.includes('server/socket')) {
-        await scanHandlers()
-        await nuxt.callHook('builder:generateApp')
-      }
+      path = relative(nuxt.options.serverDir, resolve(nuxt.options.serverDir, path))
+      const isSocketDir = /^server[\/\\]socket/.test(path)
+      
+      if (!isSocketDir || e === 'change') { return }
+
+      await scanHandlers()
+      await nuxt.callHook('builder:generateApp')
     })
 
     await scanHandlers()
@@ -105,7 +106,7 @@ export default defineNuxtModule<ModuleOptions>({
     async function scanHandlers () {
       files.length = 0
       const updatedFiles = await fg(extGlob, {
-        cwd: resolve(nuxt.options.srcDir, 'server/socket'),
+        cwd: resolve(nuxt.options.serverDir, 'socket'),
         absolute: true,
         onlyFiles: true
       })


### PR DESCRIPTION
This PR fixes an issue where the `server/socket` directory had to be placed under `src` when `nuxt.options.srcDir` was set to `srcDir: 'src'` (default is `.`).

It also addresses a logic bug in determining if a directory is a socket directory in `builder:watch`, where paths were being resolved as `server\socket\test.ts` on Windows and skipped.